### PR TITLE
Migration to dotnet and master

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,13 +4,11 @@ LABEL maintainer="extrawurst"
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y g++ git cmake make
 RUN echo "repo tag: $FLATBUFFER_TAG"
-RUN git clone --branch master --depth 1 https://github.com/google/flatbuffers.git
+RUN git clone --branch ${FLATBUFFER_TAG} --depth 1 https://github.com/google/flatbuffers.git
 # build flatc bin
 RUN cd flatbuffers && cmake -G "Unix Makefiles" && make
 RUN cp flatbuffers/flatc /usr/local/bin
 # build .net DLL
 RUN dotnet --version
-RUN mkdir -p flatbuffers/Release/
-RUN mkdir -p flatbuffers/Debug/
-RUN dotnet build -m:1 -o ./flatbuffers/Debug/ "flatbuffers/net/FlatBuffers/FlatBuffers.csproj"
-RUN dotnet build -m:1 -c Release -o ./flatbuffers/Release/ "flatbuffers/net/FlatBuffers/FlatBuffers.csproj"
+RUN dotnet build -m:1 -o ./flatbuffers/net/FlatBuffers/bin/Debug/ "flatbuffers/net/FlatBuffers/FlatBuffers.csproj"
+RUN dotnet build -m:1 -c Release -o ./flatbuffers/net/FlatBuffers/bin/Release/ "flatbuffers/net/FlatBuffers/FlatBuffers.csproj"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,16 @@
-FROM mono
+FROM mcr.microsoft.com/dotnet/sdk:5.0
 ARG FLATBUFFER_TAG=v1.12.0
 LABEL maintainer="extrawurst"
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y g++ git cmake make
 RUN echo "repo tag: $FLATBUFFER_TAG"
-RUN git clone --branch "$FLATBUFFER_TAG" --depth 1 https://github.com/google/flatbuffers.git
+RUN git clone --branch master --depth 1 https://github.com/google/flatbuffers.git
 # build flatc bin
 RUN cd flatbuffers && cmake -G "Unix Makefiles" && make
 RUN cp flatbuffers/flatc /usr/local/bin
 # build .net DLL
-RUN mono --version
-RUN msbuild -version
-RUN msbuild flatbuffers/net/FlatBuffers/FlatBuffers.csproj
-RUN msbuild /p:Configuration=Release flatbuffers/net/FlatBuffers/FlatBuffers.csproj
+RUN dotnet --version
+RUN mkdir -p flatbuffers/Release/
+RUN mkdir -p flatbuffers/Debug/
+RUN dotnet build -m:1 -o ./flatbuffers/Debug/ "flatbuffers/net/FlatBuffers/FlatBuffers.csproj"
+RUN dotnet build -m:1 -c Release -o ./flatbuffers/Release/ "flatbuffers/net/FlatBuffers/FlatBuffers.csproj"

--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,6 @@ FLATBUFFER_TAG=master
 docker-build:
 	docker build -t ${CONTAINER}:latest --build-arg FLATBUFFER_TAG=${FLATBUFFER_TAG} -f Dockerfile .
 
-schema-build:
-	docker run -it -v $(shell pwd):/fb gameroasters/flatbuffers-unity:latest /bin/bash -c "cd /fb && \
-	flatc -n --gen-onefile schema.fbs && \
-	flatc -r --gen-onefile schema.fbs"
-	mv schema_generated.rs schema.rs
-
 extract-dll:
 	docker run -v $(shell pwd):/dotnet ${CONTAINER}:latest /bin/bash -c "\
 	cp /flatbuffers/net/FlatBuffers/bin/Release/FlatBuffers.dll /dotnet && \

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,17 @@
 CONTAINER=gameroasters/flatbuffers-unity
+FLATBUFFER_TAG=master
 
 docker-build:
-	docker build -t ${CONTAINER}:latest --build-arg FLATBUFFER_TAG=v1.12.0 -f Dockerfile .
+	docker build -t ${CONTAINER}:latest --build-arg FLATBUFFER_TAG=${FLATBUFFER_TAG} -f Dockerfile .
+
+schema-build:
+	docker run -it -v $(shell pwd):/fb gameroasters/flatbuffers-unity:latest /bin/bash -c "cd /fb && \
+	flatc -n --gen-onefile schema.fbs && \
+	flatc -r --gen-onefile schema.fbs"
+	mv schema_generated.rs schema.rs
 
 extract-dll:
 	docker run -v $(shell pwd):/dotnet ${CONTAINER}:latest /bin/bash -c "\
-	cp /flatbuffers/Release/FlatBuffers.dll /dotnet && \
-	cp /flatbuffers/Debug/FlatBuffers.dll /dotnet/Flatbuffers.Debug.dll"
+	cp /flatbuffers/net/FlatBuffers/bin/Release/FlatBuffers.dll /dotnet && \
+	cp /flatbuffers/net/FlatBuffers/bin/Debug/FlatBuffers.dll /dotnet/Flatbuffers.Debug.dll"
+

--- a/Makefile
+++ b/Makefile
@@ -5,5 +5,5 @@ docker-build:
 
 extract-dll:
 	docker run -v $(shell pwd):/dotnet ${CONTAINER}:latest /bin/bash -c "\
-	cp /flatbuffers/net/FlatBuffers/bin/Release/FlatBuffers.dll /dotnet && \
-	cp /flatbuffers/net/FlatBuffers/bin/Debug/FlatBuffers.dll /dotnet/Flatbuffers.Debug.dll"
+	cp /flatbuffers/Release/FlatBuffers.dll /dotnet && \
+	cp /flatbuffers/Debug/FlatBuffers.dll /dotnet/Flatbuffers.Debug.dll"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 convenient cross platform way to use flatbuffers for unity:
 
-1. build flatbuffers .net DLL compatible with Unity 
+1. build flatbuffers .net DLL compatible with Unity
 2. easy flatc schema code generation using docker container
 
 based on [mono docker image](https://github.com/mono/docker)
@@ -18,13 +18,20 @@ based on [mono docker image](https://github.com/mono/docker)
 
 ## example for using flatc
 
+use:
+
+`make schema-build`
+
+_or_
+
 ```sh
 docker run -it -v $(shell pwd):/fb gameroasters/flatbuffers-unity:latest /bin/bash -c "cd /fb && \
 	flatc -n --gen-onefile schema.fbs && \
 	flatc -r --gen-onefile schema.fbs"
+	mv schema_generated.rs schema.rs
 ```
 
-this will generate a `schema.cs` and `schema.rs` with your schema type serialiation in rust and csharp.
+this will generate a `schema.cs` and `schema.rs` with your `schema.fbs` schema type serialiation in rust and csharp.
 
 # Todo
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ convenient cross platform way to use flatbuffers for unity:
 1. build flatbuffers .net DLL compatible with Unity
 2. easy flatc schema code generation using docker container
 
-based on [donet docker image](https://hub.docker.com/_/microsoft-dotnet-sdk/)
+based on [dotnet docker image](https://hub.docker.com/_/microsoft-dotnet-sdk/)
 
 Uses [latest master commit](https://github.com/google/flatbuffers) of flatbuffers
 

--- a/README.md
+++ b/README.md
@@ -18,11 +18,7 @@ Uses [latest master commit](https://github.com/google/flatbuffers) of flatbuffer
 
 ## example for using flatc
 
-use:
-
-`make schema-build`
-
-_or_
+Use:
 
 ```sh
 docker run -it -v $(pwd):/fb gameroasters/flatbuffers-unity:latest /bin/bash -c "cd /fb && \

--- a/README.md
+++ b/README.md
@@ -32,8 +32,3 @@ docker run -it -v $(shell pwd):/fb gameroasters/flatbuffers-unity:latest /bin/ba
 ```
 
 this will generate a `schema.cs` and `schema.rs` with your `schema.fbs` schema type serialiation in rust and csharp.
-
-# Todo
-
-- [] support flatbuffers master version
-- [] use dotnet instead of mono https://github.com/google/flatbuffers/commit/0bdf2fa156f5133b09ddac7beb326b942d524b38

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ convenient cross platform way to use flatbuffers for unity:
 1. build flatbuffers .net DLL compatible with Unity
 2. easy flatc schema code generation using docker container
 
-based on [mono docker image](https://github.com/mono/docker)
+based on [donet docker image](https://hub.docker.com/_/microsoft-dotnet-sdk/)
 
-**note:** currently only supports flatbuffers v1.12.0
+Uses [latest master commit](https://github.com/google/flatbuffers) of flatbuffers
 
 # Usage
 
@@ -32,3 +32,19 @@ docker run -it -v $(shell pwd):/fb gameroasters/flatbuffers-unity:latest /bin/ba
 ```
 
 this will generate a `schema.cs` and `schema.rs` with your `schema.fbs` schema type serialiation in rust and csharp.
+
+## extract .dll for unity
+
+use:
+
+`make extract-dll`
+
+_or_
+
+```sh
+docker run -v $(shell pwd):/dotnet gameroasters/flatbuffers-unity:latest:latest /bin/bash -c "\
+	cp /flatbuffers/net/FlatBuffers/bin/Release/FlatBuffers.dll /dotnet && \
+	cp /flatbuffers/net/FlatBuffers/bin/Debug/FlatBuffers.dll /dotnet/Flatbuffers.Debug.dll"
+```
+
+this extracts the `Flatbuffers.dll` into the current directory

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ use:
 _or_
 
 ```sh
-docker run -it -v $(shell pwd):/fb gameroasters/flatbuffers-unity:latest /bin/bash -c "cd /fb && \
+docker run -it -v $(pwd):/fb gameroasters/flatbuffers-unity:latest /bin/bash -c "cd /fb && \
 	flatc -n --gen-onefile schema.fbs && \
 	flatc -r --gen-onefile schema.fbs"
 	mv schema_generated.rs schema.rs
@@ -42,9 +42,9 @@ use:
 _or_
 
 ```sh
-docker run -v $(shell pwd):/dotnet gameroasters/flatbuffers-unity:latest:latest /bin/bash -c "\
+docker run -v $(pwd):/dotnet gameroasters/flatbuffers-unity:latest /bin/bash -c "\
 	cp /flatbuffers/net/FlatBuffers/bin/Release/FlatBuffers.dll /dotnet && \
 	cp /flatbuffers/net/FlatBuffers/bin/Debug/FlatBuffers.dll /dotnet/Flatbuffers.Debug.dll"
 ```
 
-this extracts the `Flatbuffers.dll` into the current directory
+this extracts the `Flatbuffers.dll`


### PR DESCRIPTION
- Uses Microsoft dotnet image instead of mono
- `dotnet build` instead of msbuild
- `.dll` files now stores in `flatbuffers/` folder under `Release/` and `Debug/` respectively
- Example command in reamdme does not work 